### PR TITLE
chore(projen): specify version range for peer dependency

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -124,6 +124,7 @@
     },
     {
       "name": "projen",
+      "version": ">=0.81.0 <1.0.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -25,7 +25,7 @@ const project = new cdk.JsiiProject({
     'standard-version',
   ],
   peerDeps: [
-    'projen',
+    'projen@>=0.81.0 <1.0.0',
     'constructs',
   ],
   autoApproveUpgrades: true,

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "constructs": "^10.3.0",
-    "projen": "^0.81.0"
+    "projen": ">=0.81.0 <1.0.0"
   },
   "dependencies": {
     "projen": "^0.81.0",


### PR DESCRIPTION
Update projen peer dependency to accept versions >=0.81.0 and <1.0.0. This ensures compatibility within a specific version range, potentially avoiding issues with breaking changes in future major releases. It also aligns the version specified in .projen/deps.json and .projenrc.ts with that in package.json, ensuring consistency across project configuration files.
