### PR TITLE
feat(awscdk): add watchable property and support for cdk watch tasks

### DIFF
--- a/API.md
+++ b/API.md
@@ -1355,6 +1355,7 @@ const deploymentStage: DeploymentStage = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.DeploymentStage.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.DeploymentStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.DeploymentStage.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#projen-pipelines.DeploymentStage.property.manualApproval">manualApproval</a></code> | <code>boolean</code> | *No description.* |
 
 ---
@@ -1376,6 +1377,16 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `watchable`<sup>Optional</sup> <a name="watchable" id="projen-pipelines.DeploymentStage.property.watchable"></a>
+
+```typescript
+public readonly watchable: boolean;
+```
+
+- *Type:* boolean
 
 ---
 
@@ -2310,6 +2321,7 @@ const independentStage: IndependentStage = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.IndependentStage.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.IndependentStage.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.IndependentStage.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
 | <code><a href="#projen-pipelines.IndependentStage.property.postDeploySteps">postDeploySteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 | <code><a href="#projen-pipelines.IndependentStage.property.postDiffSteps">postDiffSteps</a></code> | <code><a href="#projen-pipelines.PipelineStep">PipelineStep</a>[]</code> | *No description.* |
 
@@ -2332,6 +2344,16 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `watchable`<sup>Optional</sup> <a name="watchable" id="projen-pipelines.IndependentStage.property.watchable"></a>
+
+```typescript
+public readonly watchable: boolean;
+```
+
+- *Type:* boolean
 
 ---
 
@@ -2373,6 +2395,7 @@ const namedStageOptions: NamedStageOptions = { ... }
 | --- | --- | --- |
 | <code><a href="#projen-pipelines.NamedStageOptions.property.env">env</a></code> | <code><a href="#projen-pipelines.Environment">Environment</a></code> | *No description.* |
 | <code><a href="#projen-pipelines.NamedStageOptions.property.name">name</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#projen-pipelines.NamedStageOptions.property.watchable">watchable</a></code> | <code>boolean</code> | *No description.* |
 
 ---
 
@@ -2393,6 +2416,16 @@ public readonly name: string;
 ```
 
 - *Type:* string
+
+---
+
+##### `watchable`<sup>Optional</sup> <a name="watchable" id="projen-pipelines.NamedStageOptions.property.watchable"></a>
+
+```typescript
+public readonly watchable: boolean;
+```
+
+- *Type:* boolean
 
 ---
 

--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -55,6 +55,7 @@ export interface IndependentStage extends NamedStageOptions {
  */
 export interface NamedStageOptions extends StageOptions {
   readonly name: string;
+  readonly watchable?: boolean;
 }
 
 /**
@@ -393,10 +394,10 @@ ${appCode}
   protected createPersonalStage() {
     const stackId = this.getCliStackPattern('personal');
     this.project.addTask('deploy:personal', {
-      exec: `cdk --outputs-file cdk-outputs-personal.json deploy ${stackId}`,
+      exec: `cdk deploy --outputs-file cdk-outputs-personal.json ${stackId}`,
     });
     this.project.addTask('watch:personal', {
-      exec: `cdk deploy --watch --hotswap ${stackId}`,
+      exec: `cdk deploy --outputs-file cdk-outputs-personal.json --watch --hotswap ${stackId}`,
     });
     this.project.addTask('diff:personal', {
       exec: `cdk diff ${stackId}`,
@@ -421,6 +422,9 @@ ${appCode}
     this.project.addTask('destroy:feature', {
       exec: `cdk destroy ${stackId}`,
     });
+    this.project.addTask('watch:feature', {
+      exec: `cdk deploy --outputs-file cdk-outputs-feature.json --watch --hotswap ${stackId}`,
+    });
   }
 
   /**
@@ -435,6 +439,11 @@ ${appCode}
     this.project.addTask(`diff:${stage.name}`, {
       exec: `cdk --app ${this.app.cdkConfig.cdkout} diff ${stackId}`,
     });
+    if (stage.watchable) {
+      this.project.addTask(`watch:${stage.name}`, {
+        exec: `cdk deploy --outputs-file cdk-outputs-${stage.name}.json --watch --hotswap ${stackId}`,
+      });
+    }
   }
 
   /**
@@ -449,6 +458,11 @@ ${appCode}
     this.project.addTask(`diff:${stage.name}`, {
       exec: `cdk --app ${this.app.cdkConfig.cdkout} diff ${stackId}`,
     });
+    if (stage.watchable) {
+      this.project.addTask(`watch:${stage.name}`, {
+        exec: `cdk deploy --outputs-file cdk-outputs-${stage.name}.json --watch --hotswap ${stackId}`,
+      });
+    }
   }
 
   protected getCliStackPattern(stage: string) {


### PR DESCRIPTION
Added a `watchable` boolean property to `DeploymentStage`, `IndependentStage`, and `NamedStageOptions` interfaces. Updated the implementation to include `cdk deploy --watch --hotswap` tasks if the stage is watchable. This enhancement allows specific stages to support AWS CDK's watch mode, facilitating continuous deployment and testing.
