### PR TITLE
fix(awscdk): add support for independent stages in release tasks

### DIFF
--- a/src/awscdk/base.ts
+++ b/src/awscdk/base.ts
@@ -351,10 +351,18 @@ ${appCode}
    * based on the latest git tag and pushing the CDK assembly to the package repository.
    */
   protected createReleaseTasks() {
+    const stages = [...this.baseOptions.stages, ...this.baseOptions.independentStages ?? []];
     // Task to publish the CDK assets to all accounts
+    for (const stage of stages) {
+      this.project.addTask(`publish:assets:${stage.name}`, {
+        steps: [{
+          exec: `npx cdk-assets -p ${this.app.cdkConfig.cdkout}/${this.stackPrefix}-${stage.name}.assets.json publish`,
+        }],
+      });
+    }
     this.project.addTask('publish:assets', {
-      steps: this.baseOptions.stages.map(stage => ({
-        exec: `npx cdk-assets -p ${this.app.cdkConfig.cdkout}/${this.stackPrefix}-${stage.name}.assets.json publish`,
+      steps: stages.map(stage => ({
+        spawn: `publish:assets:${stage.name}`,
       })),
     });
 

--- a/test/__snapshots__/bash.test.ts.snap
+++ b/test/__snapshots__/bash.test.ts.snap
@@ -93,6 +93,8 @@ exports[`Bash snapshot 1`] = `
     "pre-compile": "npx projen pre-compile",
     "projen": "npx projen",
     "publish:assets": "npx projen publish:assets",
+    "publish:assets:dev": "npx projen publish:assets:dev",
+    "publish:assets:prod": "npx projen publish:assets:prod",
     "release:push-assembly": "npx projen release:push-assembly",
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -229,6 +229,8 @@ exports[`Github snapshot 3`] = `
     "pre-compile": "npx projen pre-compile",
     "projen": "npx projen",
     "publish:assets": "npx projen publish:assets",
+    "publish:assets:dev": "npx projen publish:assets:dev",
+    "publish:assets:prod": "npx projen publish:assets:prod",
     "release:push-assembly": "npx projen release:push-assembly",
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",
@@ -429,8 +431,24 @@ exports[`Github snapshot 4`] = `
       "name": "publish:assets",
       "steps": [
         {
+          "spawn": "publish:assets:dev",
+        },
+        {
+          "spawn": "publish:assets:prod",
+        },
+      ],
+    },
+    "publish:assets:dev": {
+      "name": "publish:assets:dev",
+      "steps": [
+        {
           "exec": "npx cdk-assets -p cdk.out/testapp-dev.assets.json publish",
         },
+      ],
+    },
+    "publish:assets:prod": {
+      "name": "publish:assets:prod",
+      "steps": [
         {
           "exec": "npx cdk-assets -p cdk.out/testapp-prod.assets.json publish",
         },
@@ -1087,6 +1105,14 @@ exports[`Github snapshot with multi stack 2`] = `
     },
     "publish:assets": {
       "name": "publish:assets",
+      "steps": [
+        {
+          "spawn": "publish:assets:dev",
+        },
+      ],
+    },
+    "publish:assets:dev": {
+      "name": "publish:assets:dev",
       "steps": [
         {
           "exec": "npx cdk-assets -p cdk.out/testapp-dev.assets.json publish",

--- a/test/__snapshots__/gitlab.test.ts.snap
+++ b/test/__snapshots__/gitlab.test.ts.snap
@@ -234,6 +234,8 @@ exports[`Gitlab snapshot 2`] = `
     "pre-compile": "npx projen pre-compile",
     "projen": "npx projen",
     "publish:assets": "npx projen publish:assets",
+    "publish:assets:dev": "npx projen publish:assets:dev",
+    "publish:assets:prod": "npx projen publish:assets:prod",
     "release:push-assembly": "npx projen release:push-assembly",
     "synth": "npx projen synth",
     "synth:silent": "npx projen synth:silent",


### PR DESCRIPTION
Extended the release task creation to include both base and independent stages. Each stage now has its own publish task, which is spawned by the main publish:assets task. Updated test snapshots to reflect these changes, ensuring consistent handling and publishing of assets across all specified stages.

Fixes #84